### PR TITLE
Hotfix 1.1.7 | switch from passed in $request variable to use the request() helper instead to not have to explicitly pass in the $request #8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/error-403",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "type": "library",
     "description": "Wayne State University Error 403 HTTP Status",
     "keywords": ["status","http","error","403"],

--- a/dist/403.php
+++ b/dist/403.php
@@ -18,8 +18,8 @@
             window.dataLayer.push({
                 'event': 'http_error',
                 'error_code': '403',
-                'page': '{{ $request->server("HTTP_HOST") }}{{ $request->server("REQUEST_URI") }}',
-                'referrer': '{{ $request->server("HTTP_REFERER") }}'
+                'page': '{{ request()->server("HTTP_HOST") }}{{ request()->server("REQUEST_URI") }}',
+                'referrer': '{{ request()->server("HTTP_REFERER") }}'
             });
             (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
switch from passed in $request variable to use the request() helper instead to not have to explicitly pass in the $request #8